### PR TITLE
fix: use powercord/http instead of an external api

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { Plugin } = require('powercord/entities');
 const { inject, uninject } = require('powercord/injector');
+const { get } = require('powercord/http');
 const { getModule } = require('powercord/webpack');
 
 module.exports = class YTEmbedFix extends Plugin {
@@ -24,9 +25,8 @@ module.exports = class YTEmbedFix extends Plugin {
                                 //this.log('[YT EMBED FIX] found YouTube embed', context, video, video.url);
 
                                 // region only forward blocked embeds
-                                // this is cursed, but I don't want to host my own proxy for this
-                                fetch(`https://api.allorigins.win/get?url=${video.url}`).then(res => res.json()).then(data => {
-                                    const { contents } = data;
+                                get(video.url).then(res => {
+                                    const contents = res.body.toString()
                                     //this.log('[YT EMBED FIX] res', contents);
 
                                     // blocked embeds contain this meta tag

--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,6 @@
     "version": "1.0.0",
     "description": "Circumvent YouTube embed restrictions",
     "author": "D3SOX",
-    "license": "GPL-3.0"
+    "license": "GPL-3.0",
+    "permissions": [ "ext_api" ],
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,5 +4,5 @@
     "description": "Circumvent YouTube embed restrictions",
     "author": "D3SOX",
     "license": "GPL-3.0",
-    "permissions": [ "ext_api" ],
+    "permissions": [ "ext_api" ]
 }


### PR DESCRIPTION
this is untested but should do the same thing